### PR TITLE
Add an impl of deref_mut

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,12 @@ fn impl_newtype_proxy(ast: &MacroInput) -> quote::Tokens {
                             &self.0
                         }
                     }
+                    
+                    impl#impl_vars ::std::ops::DerefMut for #name#type_vars #where_clause {
+                        fn deref_mut(&mut self) -> &mut #inner_type {
+                            &mut self.0
+                        }
+                    }
                 }
             } else {
                 panic!("derive(NewtypeProxy) only supports single value newtypes.")

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -10,8 +10,10 @@ mod tests {
     #[test]
     fn it_works() {
         let some_vec: Vec<i64> = vec![1, 2, 3];
-        let my_vec = MyVec::from(some_vec.clone());
+        let mut my_vec = MyVec::from(some_vec.clone());
         assert_eq!(3, my_vec.len());
         assert_eq!(some_vec, *my_vec);
+        my_vec.push(4);
+        assert_eq!(4, my_vec.len());
     }
 }


### PR DESCRIPTION
This is fairly self explanatory. I use newtype structs a bunch with [specs](https://github.com/slide-rs/specs) so this would really help me out by getting rid of all the `thing.0`s everywhere.